### PR TITLE
Add JSON utility script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,27 @@
+# JSON Tool
+
+A small command-line utility for pretty-printing or minifying JSON data.
+
+## Usage
+
+```
+python3 json_tool.py [--pretty | --minify] [FILE]
+```
+
+- If `FILE` is omitted, the tool reads JSON from `stdin`.
+- By default or with `--pretty`, the output is formatted with indentation.
+- With `--minify`, the output contains no unnecessary whitespace.
+
+## Examples
+
+Pretty-print a JSON file:
+
+```
+python3 json_tool.py --pretty data.json
+```
+
+Minify JSON from `stdin`:
+
+```
+cat data.json | python3 json_tool.py --minify
+```

--- a/json_tool.py
+++ b/json_tool.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Simple JSON utility for pretty-printing or minifying JSON data."""
+
+import argparse
+import json
+import sys
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Pretty-print or minify JSON from a file or stdin"
+    )
+    parser.add_argument(
+        "file",
+        nargs="?",
+        type=argparse.FileType('r'),
+        default=sys.stdin,
+        help="JSON file to read; defaults to stdin",
+    )
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument(
+        "--pretty",
+        action="store_true",
+        help="Output formatted JSON (default)",
+    )
+    group.add_argument(
+        "--minify",
+        action="store_true",
+        help="Output minified JSON",
+    )
+
+    args = parser.parse_args()
+
+    data = json.load(args.file)
+
+    if args.minify:
+        json.dump(data, sys.stdout, separators=(",", ":"))
+    else:
+        json.dump(data, sys.stdout, indent=4, sort_keys=True)
+        sys.stdout.write("\n")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add README explaining JSON Tool usage
- add `json_tool.py` for pretty-printing or minifying JSON data

## Testing
- `python3 json_tool.py <<'EOF'
{"a":1,"b":2}
EOF`
- `python3 json_tool.py --minify <<'EOF'
{"a": 1, "b": [1,2,3]}
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68465487f3288324ba25870c8b81391d